### PR TITLE
Prepare for release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-minify-html
-version = 1.0.0
+version = 0.0.0
 description = Use minify-html, the extremely fast HTML + JS + CSS minifier, with Django.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -25,7 +25,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
Downgrade version so release script can bump it, and drop accidental Python 3.7 classifier