### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py38-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py38']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_minify_html/decorators.py
+++ b/src/django_minify_html/decorators.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import TypeVar
 
 from django.http.response import HttpResponseBase
 

--- a/src/django_minify_html/middleware.py
+++ b/src/django_minify_html/middleware.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Callable
+from typing import Awaitable
+from typing import Callable
 
 import minify_html
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
+from django.http import HttpResponse
 from django.http.response import HttpResponseBase
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
 
 from django_minify_html.middleware import MinifyHtmlMiddleware
-from tests.views import basic_html, basic_html_minified
+from tests.views import basic_html
+from tests.views import basic_html_minified
 
 
 class NoCssMiddleware(MinifyHtmlMiddleware):

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 
 from django_minify_html.decorators import no_html_minification
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
