### PR TITLE
Fix Content-Length header to count bytes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Fix the value in the ``Content-Length`` header to correctly count bytes, rather than unicode characters.
+
+  Thanks to Haydn Greatnews in `PR #143 <https://github.com/adamchainz/django-minify-html/pull/143>`__.
+
 1.6.0 (2023-06-14)
 ------------------
 

--- a/src/django_minify_html/middleware.py
+++ b/src/django_minify_html/middleware.py
@@ -55,7 +55,7 @@ class MinifyHtmlMiddleware:
             minified_content = minify_html.minify(content, **self.minify_args)
             response.content = minified_content
             if "Content-Length" in response:
-                response["Content-Length"] = len(minified_content)
+                response["Content-Length"] = len(response.content)
 
     minify_args = {
         "minify_css": True,

--- a/tests/views.py
+++ b/tests/views.py
@@ -5,8 +5,8 @@ from django.http import StreamingHttpResponse
 
 from django_minify_html.decorators import no_html_minification
 
-basic_html = b"<!doctype html><html><body><p>Hi</p></body></html>"
-basic_html_minified = b"<!doctypehtml><body><p>Hi"
+basic_html = "<!doctype html><html><body><p>Hi 👋</p></body></html>".encode()
+basic_html_minified = "<!doctypehtml><body><p>Hi 👋".encode()
 
 
 def streaming(request):


### PR DESCRIPTION
The `minified_content` is a string variable, but the content-length must always be specified in bytes.

Using `response.content` works around this, as `response` has a [setter on content](https://github.com/django/django/blob/048d75aeb1e2b1c08b1b9ec359397f00aec1b57d/django/http/response.py#L396), that encodes the bytes before they're stored