### PR TITLE
Use `minify-html-fallback` so users don't need to build wheels on Python 3.13 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.13.0 (2025-03-20)
+-------------------
+
+* Temporarily switch to using `minify-html-fallback` as to allow pre-built wheels on Python 3.13.
+
 1.12.0 (2025-02-06)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ But it is much slower, since it does the minification in Python.
 At time of writing, it is also unmaintained, with no release since March 2019.
 
 There are other minifiers out there, but in benchmarks `minify-html <https://github.com/wilsonzlin/minify-html>`__ surpasses them all.
-It’s a really well optimized and tested Rust library, and seems to be the best available HTML minifier.
+It’s a really well optimized and tested Rust library, and seems to be the best available HTML minifier. As of writing, it's been more than a year since `minify-html` was last released. This means that, among other things, pre-built wheels for Python 3.13 is not available in that package. For that reason, we depend `minify-html-fallback` (which is just a fork with more recent releases) until a new version of the main library is released again.
 
 Historically, Cloudflare provided automatic minification (`removed August 2024 <https://community.cloudflare.com/t/deprecating-auto-minify/655677>`__).
 This was convenient at the CDN layer, since it requires no application changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ urls = { Changelog = "https://github.com/adamchainz/django-minify-html/blob/main
 [dependency-groups]
 test = [
   "coverage[toml]",
-  "minify-html",
+  "minify-html-fallback>=0.16.4",
   "pytest",
   "pytest-django",
   "pytest-randomly",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "django-minify-html"
-version = "1.12.0"
+version = "1.13.0"
 description = "Use minify-html, the extremely fast HTML + JS + CSS minifier, with Django."
 readme = "README.rst"
 keywords = [
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
   "asgiref>=3.6",
   "django>=4.2",
-  "minify-html",
+  "minify-html-fallback>=0.16.4",
 ]
 urls = { Changelog = "https://github.com/adamchainz/django-minify-html/blob/main/CHANGELOG.rst", Funding = "https://adamj.eu/books/", Repository = "https://github.com/adamchainz/django-minify-html" }
 

--- a/src/django_minify_html/middleware.py
+++ b/src/django_minify_html/middleware.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable
 from typing import Callable
 
-import minify_html
+import minify_html_fallback
 from asgiref.sync import iscoroutinefunction
 from asgiref.sync import markcoroutinefunction
 from django.http import HttpRequest
@@ -51,7 +51,7 @@ class MinifyHtmlMiddleware:
         if self.should_minify(request, response):
             assert isinstance(response, HttpResponse)
             content = response.content.decode(response.charset)
-            minified_content = minify_html.minify(content, **self.minify_args)
+            minified_content = minify_html_fallback.minify(content, **self.minify_args)
             response.content = minified_content
             if "Content-Length" in response:
                 response["Content-Length"] = len(response.content)

--- a/tests/views.py
+++ b/tests/views.py
@@ -6,7 +6,7 @@ from django.http import StreamingHttpResponse
 from django_minify_html.decorators import no_html_minification
 
 basic_html = "<!doctype html><html><body><p>Hi 👋</p></body></html>".encode()
-basic_html_minified = "<!doctypehtml><body><p>Hi 👋".encode()
+basic_html_minified = "<!doctype html><body><p>Hi 👋".encode()
 
 
 def streaming(request):

--- a/uv.lock
+++ b/uv.lock
@@ -113,8 +113,8 @@ name = "django"
 version = "4.2.19"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10'",
     "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
 ]
 dependencies = [
     { name = "asgiref" },
@@ -187,7 +187,7 @@ dependencies = [
     { name = "django", version = "5.0.12", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and extra == 'group-18-django-minify-html-django50') or (extra == 'group-18-django-minify-html-django50' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django50' and extra == 'group-18-django-minify-html-django52') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django50') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django52') or (extra == 'group-18-django-minify-html-django51' and extra == 'group-18-django-minify-html-django52')" },
     { name = "django", version = "5.1.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django51' and extra == 'group-18-django-minify-html-django52') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django50') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django52') or (extra == 'group-18-django-minify-html-django50' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django50' and extra == 'group-18-django-minify-html-django52')" },
     { name = "django", version = "5.2b1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and extra != 'group-18-django-minify-html-django42' and extra != 'group-18-django-minify-html-django50' and extra != 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django50') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django42' and extra == 'group-18-django-minify-html-django52') or (extra == 'group-18-django-minify-html-django50' and extra == 'group-18-django-minify-html-django51') or (extra == 'group-18-django-minify-html-django50' and extra == 'group-18-django-minify-html-django52') or (extra == 'group-18-django-minify-html-django51' and extra == 'group-18-django-minify-html-django52')" },
-    { name = "minify-html" },
+    { name = "minify-html-fallback" },
 ]
 
 [package.dev-dependencies]
@@ -215,7 +215,7 @@ test = [
 requires-dist = [
     { name = "asgiref", specifier = ">=3.6" },
     { name = "django", specifier = ">=4.2" },
-    { name = "minify-html" },
+    { name = "minify-html-fallback", specifier = ">=0.16.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -287,6 +287,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/71/94/6019e2e8054c4c8ad6200ab067445b09b22946360b544ed10699016cba55/minify_html-0.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cda674cc68ec3b9ebf61f2986f3ef62de60ce837a58860c6f16b011862b5d533", size = 2240900 },
     { url = "https://files.pythonhosted.org/packages/20/cd/5d786a1364c4eb8b6c8d934b2d9afc60d0abaf0c3f5bd1b121eb1ad343af/minify_html-0.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b071ded7aacbb140a7e751d49e246052f204b896d69663a4a5c3a27203d27f6", size = 2395945 },
     { url = "https://files.pythonhosted.org/packages/b8/87/34ff1b12748d5051e7907809fba7241ac3fb9ea2e3079dcb623d43c5f861/minify_html-0.15.0-cp39-none-win_amd64.whl", hash = "sha256:ef6dc1950e04b7566c1ece72712674416f86fef8966ca026f6c5580d840cd354", size = 2382566 },
+]
+
+[[package]]
+name = "minify-html-fallback"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/1b/e5cda58711b30d766fc7a0e6b75c03f37a13faf50082e1b1c30e61864589/minify_html_fallback-0.16.4.tar.gz", hash = "sha256:42eb8d43fbf9486dd51bc79c03a0d0ad0a67e04d25b2b1bccf617806e9c74adb", size = 88024 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2d/a3b71e92020ce323f5aebb1920fd65b38a165e1589c3fb0d36fc14ddfe55/minify_html_fallback-0.16.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f4233556376651653876b9b28f645c98f901106594e798fd761db7e0d4705692", size = 2460605 },
+    { url = "https://files.pythonhosted.org/packages/34/a4/6451ebee879a7768df58e6f1c2816b0962011e50c777642bded957ee3660/minify_html_fallback-0.16.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7b8e58e5be6ee3ed0b3a0678e8182d8314b4396184c53fe0d6683ee991ca1e64", size = 2234732 },
+    { url = "https://files.pythonhosted.org/packages/9d/33/a11f093fbe3ebccfe48439a9621fcec28f91c369080eb2515f441934441f/minify_html_fallback-0.16.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa127b77489ecaece258b5f731740143f608dc17edea033be2897da1e46b4b51", size = 2287572 },
+    { url = "https://files.pythonhosted.org/packages/7c/c9/c73c244badbedd6bd27dc4108a09e56f5bb3063e33c2af8181967c3c4747/minify_html_fallback-0.16.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcc567434d4f3627315fd0045ce6075ac8f59711d6d997eee98d6ecdafba7c54", size = 2555174 },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/de8484d30bb7a20b2d021c2be6bba97c99dda894a14103a0ae53987abcba/minify_html_fallback-0.16.4-cp310-cp310-win_amd64.whl", hash = "sha256:d5cceef5af8c9ef4971f6710d3534c85e480479256f0b2d077d4d5cf8ab776d5", size = 2538017 },
+    { url = "https://files.pythonhosted.org/packages/09/7c/da7b1106d4d7cc8643f870d35f872bdeecb98b44dfad4b2fcaf79e154307/minify_html_fallback-0.16.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c8e5664e36308ae96593423437c9ece2249d4ebe8d649c6b65582c32e9fdf4e5", size = 2460768 },
+    { url = "https://files.pythonhosted.org/packages/e6/2a/034282a0e2e8eeb0eb750b7c6fdc17c761ce090e22330f38f4a02172c6ca/minify_html_fallback-0.16.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f4eb1ac0746301ff271c2117b3c9285175037ab12774f4fa0843786c75254dae", size = 2235082 },
+    { url = "https://files.pythonhosted.org/packages/cd/6d/e27fc28ab87fa38aae71a4558dbd033b5b7887e587c5f7e060621be6b327/minify_html_fallback-0.16.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c37be4bd2a5dc4252daf66b4a20134f30064cd1dff8063cca5c40c80ee8127a3", size = 2287864 },
+    { url = "https://files.pythonhosted.org/packages/97/c2/3099aa208ac571e63594a75be05dba7fd19fb42f13766f451c4c3428ff4f/minify_html_fallback-0.16.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9784797a0a80fa89b9398a1510ebf4aecfd29c378f2c9172ca0fb18523ceb930", size = 2555248 },
+    { url = "https://files.pythonhosted.org/packages/00/f3/cf371f9ec0a25f270a454743eed5b26aed4b5aa68a3f76f0998056065cb0/minify_html_fallback-0.16.4-cp311-cp311-win_amd64.whl", hash = "sha256:907f49f1020f9b4e4302342a680b64466fe783198609dfbed6c7994e89b5b106", size = 2538009 },
+    { url = "https://files.pythonhosted.org/packages/1c/8c/5a2a6d675c5d0201a17439596be01c00370c1841a026eb1ba2b607d1f47f/minify_html_fallback-0.16.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:28116c447f79201747fc1ad7e66bd349d7d8d32d6e47679730f891faffe98701", size = 2460523 },
+    { url = "https://files.pythonhosted.org/packages/22/05/1db1ceec8f04330a46c7d13d68b148d002836781a022053283a2942b2e5d/minify_html_fallback-0.16.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:307d8af94c189881536ef03af085d77234d8b57b8082841a74b8713b3b029c66", size = 2234965 },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/d385c955667f67f52cb947f1d9e38150c80e01873d6256aeb7f66ba5f651/minify_html_fallback-0.16.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1109e5cb2e24e1e451b224856d145bc21bcda5f39d517cdb95380c98a2d43f26", size = 2287566 },
+    { url = "https://files.pythonhosted.org/packages/67/71/faeec593174db9719632e09909d0c50338e054b53c094ffc179dbe006c69/minify_html_fallback-0.16.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e699797f7c2497a330f611759c3e9cb29aa78aadf424fb766f7855e6e8663bdd", size = 2555150 },
+    { url = "https://files.pythonhosted.org/packages/ce/37/804597b07c831fa1e76bfd871bd3d26f52a62c9347ccf786b95d7098a88a/minify_html_fallback-0.16.4-cp312-cp312-win_amd64.whl", hash = "sha256:b80f0bdbcda107efcb79cbf0f946b6eff48cab5206f72cb712c08fcab22ef02e", size = 2537778 },
+    { url = "https://files.pythonhosted.org/packages/a0/46/eb6821ace7af706b97abf0ad8ad4ac52a4558d474e58b77ed1accd0bef36/minify_html_fallback-0.16.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:db5d250674f3c382897f24e9ed9f0cdabee7a7cc1df30240cd8e8dc1667cd34f", size = 2460157 },
+    { url = "https://files.pythonhosted.org/packages/07/82/b18c361309cdfa721abda2b353e84598ac9eb2b56c84cc47d920905c94e0/minify_html_fallback-0.16.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e246ab145b5b6d1c082efa92a25be8ed46c333f03d5cd49692071d5617cd74ac", size = 2234694 },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/d8d650a07a89d4f9f34e59878fa2c0ad8dfb8696b7b5683a4b414387fdea/minify_html_fallback-0.16.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6efd7e8e9de4427c0cd4a7771e8df7f5d39b1b679cd1e42d7f6c9b3d92042e29", size = 2287245 },
+    { url = "https://files.pythonhosted.org/packages/50/f4/2489af54658ab14f8cc61007438b836aaa4bd397e410660eaea88dc6d4d0/minify_html_fallback-0.16.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e09c1a3acf1e2b9f75d0d8796b28425fc95d7d0ade33457fc9810bd941fb0e29", size = 2555039 },
+    { url = "https://files.pythonhosted.org/packages/41/9e/b4c94ea09a72a98b7dfe574ff932d024db2b756ee8b3f04b0d4a1978c921/minify_html_fallback-0.16.4-cp313-cp313-win_amd64.whl", hash = "sha256:98d5fca20d0b8ea3f31b88c64164ff00ff550986f0572f29258312102082bdb4", size = 2538045 },
+    { url = "https://files.pythonhosted.org/packages/3d/23/203ad64cdb2582f78792be317b3ac666a6200eff48e37c404e93ba9e7615/minify_html_fallback-0.16.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:82c0d6eef11f6089ccdea571db81dc836d9ff6e81461a727c70255371eab1c0f", size = 2461022 },
+    { url = "https://files.pythonhosted.org/packages/65/17/7f4b71108e363ac4af54fb6ab8e465491fab832ae8c1486d2a207532c898/minify_html_fallback-0.16.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ac32b9b6cb8231a02cc4c69852885d877aa65f72aaaae25620b6520cf36a3e05", size = 2234632 },
+    { url = "https://files.pythonhosted.org/packages/aa/fe/372237dab7df03745a2b7ea886ebde3c2183eb00e76a2c090f0ff1f8a27e/minify_html_fallback-0.16.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4944dd73c922cc85f2c21b90100861cd5c147e22b8509883cf1e2a6a9005e94a", size = 2288010 },
+    { url = "https://files.pythonhosted.org/packages/c8/8e/a8e86ea71034d1212a748a8ee3046d64568bfa0ece4190032c9f7a49ed0b/minify_html_fallback-0.16.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94c9167e82a3c271e33ce5e1a9bf46cb0dcf96feb92846c9ce9cb693813f25d9", size = 2555124 },
+    { url = "https://files.pythonhosted.org/packages/8e/2d/237d8bf99c7a45ce416472871d74c110ccc5c549fb9230b3aba2eb2661a2/minify_html_fallback-0.16.4-cp39-cp39-win_amd64.whl", hash = "sha256:2ada74a6d6719e7115c675e888fecaeca9b9ee277e229299dc2f1536811ca4a7", size = 2538053 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ django52 = [
 ]
 test = [
     { name = "coverage", extra = ["toml"] },
-    { name = "minify-html" },
+    { name = "minify-html-fallback" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "pytest-randomly" },
@@ -225,7 +225,7 @@ django51 = [{ name = "django", marker = "python_full_version >= '3.10'", specifi
 django52 = [{ name = "django", marker = "python_full_version >= '3.10'", specifier = ">=5.2a1,<6" }]
 test = [
     { name = "coverage", extras = ["toml"] },
-    { name = "minify-html" },
+    { name = "minify-html-fallback", specifier = ">=0.16.4" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "pytest-randomly" },
@@ -259,34 +259,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
-]
-
-[[package]]
-name = "minify-html"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/8a/c921cd4b3e364c871be418c1694b315e5fa823eb8180d89f99d9a61aa8fe/minify_html-0.15.0.tar.gz", hash = "sha256:cf4c36b6f9af3b0901bd2a0a29db3b09c0cdf0c38d3dde28e6835bce0f605d37", size = 96948 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a9/3aaf8fbf5f673892eb9bc8ddedf0f1fc41f9ac0a2178d9b402f96241359d/minify_html-0.15.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:afd76ca2dc9afa53b66973a3a66eff9a64692811ead44102aa8044a37872e6e2", size = 2307896 },
-    { url = "https://files.pythonhosted.org/packages/16/1a/42c5710df7272819f200680bbc32a60b9d8c1fe6f93fcae74f15ed333baf/minify_html-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f37ce536305500914fd4ee2bbaa4dd05a039f39eeceae45560c39767d99aede0", size = 2164232 },
-    { url = "https://files.pythonhosted.org/packages/80/4a/68bb3628661022a98d047fa036c334c6783bad28eed424d3be9934b4f117/minify_html-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e6d4f97cebb725bc1075f225bdfcd824e0f5c20a37d9ea798d900f96e1b80c0", size = 2240953 },
-    { url = "https://files.pythonhosted.org/packages/65/cb/2c07378be27fb06f8e4ff9c45713f93ba278c59654121dfbd05217fc2b7a/minify_html-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e47197849a1c09a95892d32df3c9e15f6d0902c9ae215e73249b9f5bca9aeb97", size = 2395974 },
-    { url = "https://files.pythonhosted.org/packages/c1/6f/505df9f831723a9c5d4a50e8c14ef925ee1200bdac8a2392a9ff51e96115/minify_html-0.15.0-cp310-none-win_amd64.whl", hash = "sha256:7af72438d3ae6ea8b0a94c038d35c9c22c5f8540967f5fa2487f77b2cdb12605", size = 2382572 },
-    { url = "https://files.pythonhosted.org/packages/d1/97/c58b0d768d5aeea3aceb3312c45a56adc8fca61a08e9a293a63e4ebb5327/minify_html-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a23a8055e65fa01175ddd7d18d101c05e267410fa5956c65597dcc332c7f91dd", size = 2307981 },
-    { url = "https://files.pythonhosted.org/packages/3f/fd/e159a09eda87b6c932b2a4508f54b2198f3622c2ae2715db8912f885d088/minify_html-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:597c86f9792437eee0698118fb38dff42b5b4be6d437b6d577453c2f91524ccc", size = 2164161 },
-    { url = "https://files.pythonhosted.org/packages/f3/6a/c22b18ca570c33c3edf895ecf8661501d9e17e9d50c3a2d3ea956f16cd90/minify_html-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b2aadba6987e6c15a916a4627b94b1db3cbac65e6ae3613b61b3ab0d2bb4c96", size = 2240915 },
-    { url = "https://files.pythonhosted.org/packages/a0/e2/ed7e62f62a54774c411a0e28ef67a7d1ccb84ab1a933f6b59362c83d78c1/minify_html-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4c4ae3909e2896c865ebaa3a96939191f904dd337a87d7594130f3dfca55510", size = 2395989 },
-    { url = "https://files.pythonhosted.org/packages/5d/56/323ba007a5bb42ea375a2bc1c3d60913716e994b4fe56bd2a9046d6e974f/minify_html-0.15.0-cp311-none-win_amd64.whl", hash = "sha256:dc2df1e5203d89197f530d14c9a82067f3d04b9cb0118abc8f2ef8f88efce109", size = 2382515 },
-    { url = "https://files.pythonhosted.org/packages/30/a7/b0a1c3a3c10c00b28732b1d8e54fbe2e0d7f586397592d35952ca7ec156c/minify_html-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2a9aef71b24c3d38c6bece2db3bf707443894958b01f1c27d3a6459ba4200e59", size = 2307989 },
-    { url = "https://files.pythonhosted.org/packages/09/df/d011e38521551ddab4d31d389691aa5d3eaf19cfbab993a9d366032a6608/minify_html-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:70251bd7174b62c91333110301b27000b547aa2cc06d4fe6ba6c3f11612eecc9", size = 2164108 },
-    { url = "https://files.pythonhosted.org/packages/0f/5a/9b53f0215237f1693242cd6fbafe73dd88050454f2715b6d5123ca444da0/minify_html-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1056819ea46e9080db6fed678d03511c7e94c2a615e72df82190ea898dc82609", size = 2240974 },
-    { url = "https://files.pythonhosted.org/packages/a0/ae/786cd6775d8891fe2a4b5774753a00c95fd6ec3013086c92c2970c4371dc/minify_html-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea315ad6ac33d7463fac3f313bba8c8d9a55f4811971c203eed931203047e5c8", size = 2395919 },
-    { url = "https://files.pythonhosted.org/packages/90/f0/23ea4cbaff3f83c4f8802bfda2aebbdd02fb84595567aeb86be84f6aa055/minify_html-0.15.0-cp312-none-win_amd64.whl", hash = "sha256:01ea40dc5ae073c47024f02758d5e18e55d853265eb9c099040a6c00ab0abb99", size = 2382578 },
-    { url = "https://files.pythonhosted.org/packages/8d/ee/bde9639cebaa02c8371634d7fc167d566eb84e6eb0ff827e987906deeae9/minify_html-0.15.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:7a5eb7e830277762da69498ee0f15d4a9fa6e91887a93567d388e4f5aee01ec3", size = 2307936 },
-    { url = "https://files.pythonhosted.org/packages/c0/a4/0f03d1132428bc20ea289212ad42ba781530673b2096d13db200243c0317/minify_html-0.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:92375f0cb3b4074e45005e1b4708b5b4c0781b335659d52918671c083c19c71e", size = 2164201 },
-    { url = "https://files.pythonhosted.org/packages/71/94/6019e2e8054c4c8ad6200ab067445b09b22946360b544ed10699016cba55/minify_html-0.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cda674cc68ec3b9ebf61f2986f3ef62de60ce837a58860c6f16b011862b5d533", size = 2240900 },
-    { url = "https://files.pythonhosted.org/packages/20/cd/5d786a1364c4eb8b6c8d934b2d9afc60d0abaf0c3f5bd1b121eb1ad343af/minify_html-0.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b071ded7aacbb140a7e751d49e246052f204b896d69663a4a5c3a27203d27f6", size = 2395945 },
-    { url = "https://files.pythonhosted.org/packages/b8/87/34ff1b12748d5051e7907809fba7241ac3fb9ea2e3079dcb623d43c5f861/minify_html-0.15.0-cp39-none-win_amd64.whl", hash = "sha256:ef6dc1950e04b7566c1ece72712674416f86fef8966ca026f6c5580d840cd354", size = 2382566 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "django-minify-html"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "asgiref" },


### PR DESCRIPTION
This library uses the brilliant `minify-html` library for the actual minification. However, it seems like that library is starting to become slightly unmaintained. It's been over a year since a new release was made. Among other things, this means that there are no pre-built wheels on Python 3.13, which might make it difficult to use in certain environments where installing the Rust toolchain is time-consuming or inconvenient for other reasons.

This PR switches the underlying library used to be `minify-html-fallback`, a fork I made of `minify-html` that doesn't do much else than simply fixing the build process for newer Python versions - and then actually has been released.

Once `minify-html` is released with pre-built Python 3.13 wheels, I would recommend to switch back. But for now, this fallback can be used to enhance the installation process.

In summary, these are all the changes in the PR:

* Change `minify-html` to `minify-html-fallback` dependency in `pyproject.toml` and `uv.lock`
* Change import accordingly in `middleware.py`
* Bump version number to 1.13.0 to prepare for release
* Adds release notes for 1.13.0
* Adds a small note to the README that `minify-html-fallback` is used instead of `minify-html` and the motivation for why
* Fix missing space in test due to `minify-html` default value changes